### PR TITLE
Prevent scoping the selector twice

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -278,6 +278,48 @@ test('should add single extra scope correctly for same-level rules', () => {
 `)
 })
 
+test('should add single extra scope correctly for nested scopes after an @media rule', () => {
+  const stylis = new Stylis()
+  stylis.use(extraScopePlugin('#my-scope'))
+
+  const actual = stylis(
+    '.some-class',
+    `
+    min-width: 12rem;
+
+    div {
+      height: 10px;
+    }
+
+    @media (min-width: 768px) {
+      margin: 0 20px 0 0;
+    }
+    
+    span {
+      height: 30px;
+    }
+  `,
+  )
+
+  expect(formatCss(actual)).toMatchInlineSnapshot(`
+"#my-scope .some-class {
+  min-width: 12rem;
+}
+#my-scope .some-class div {
+  height: 10px;
+}
+@media (min-width: 768px) {
+  #my-scope .some-class {
+    margin: 0 20px 0 0;
+  }
+}
+#my-scope .some-class span {
+  height: 30px;
+}
+"
+`)
+})
+
 test('multiple extra scopes', () => {
   const stylis = new Stylis()
   stylis.use(extraScopePlugin('#my-scope', '#my-second-scope'))

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,17 @@ export default function createExtraScopePlugin(...extra) {
     seen.add(selectors)
 
     for (let i = 0; i < selectors.length; i++) {
-      selectors[i] = scopes.map(scope => `${scope}${selectors[i]}`).join(',')
+      selectors[i] = scopes
+        .map(scope => {
+        // Avoid to apply scope twice to the selector to prevent issues
+        // #my-scope #my-scope .some-class span
+          const s = selectors[i]
+          if (s && s.indexOf(scope) >= 0) {
+            return s
+          }
+          return `${scope}${s}`
+        })
+        .join(',')
     }
   }
 


### PR DESCRIPTION
Avoid to apply scope twice to the selector to prevent issues
`#my-scope #my-scope .some-class span`

instead of what it should be:

`#my-scope .some-class span`

Using this for a styled-components component:
```
div {
  height: 10px;
}

@media (min-width: 768px) {
  margin: 0 20px 0 0;
}
    
span {
  height: 30px;
}
```

Would generate something like this below. Everything after the @media would be scoped incorrectly. Check the double `.app-scope .app-scope for the last span`

```
.app-scope .gTkTZq div {
  height: 10px
}
@media only screen and (max-width:768px)
{
  .app-scope .gTkTZq{left:-8px;}
}
.app-scope .app-scope .gTkTZq span{
  height: 30px;
}
```